### PR TITLE
Add joint control and lift drag plugins

### DIFF
--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -57,15 +57,20 @@
     <link name="ccw_servo_link">
       <pose relative_to="ccw_servo_joint">0 0 0 0 0 0</pose>
       <inertial>
-        <pose>-5e-06 -0.003367 0.021721 0 0 0</pose>
+        <!-- <pose>-5e-06 -0.003367 0.021721 0 0 0</pose> -->
+        <pose>0 0 0 0 0 0</pose>
         <mass>0.032</mass> <!-- default : 0.0318045 -->
+        <!--
+          Estimate for inertial based on a solid box with dimensions:
+          <size>0.03 0.04 0.02</size>
+        -->
         <inertia>
-          <ixx>4.59202e-06</ixx>
-          <ixy>-7.94305e-11</ixy>
-          <ixz>-1.03122e-09</ixz>    
-          <iyy>3.56948e-06</iyy>
-          <iyz>1.17656e-07</iyz>
-          <izz>5.80439e-06</izz>
+          <ixx>5.33333E-06</ixx>    <!-- 4.59202e-06 -->
+          <ixy>0</ixy>              <!-- -7.94305e-11 -->
+          <ixz>0</ixz>              <!-- -1.03122e-09 -->
+          <iyy>3.46667E-06</iyy>    <!-- 3.56948e-06 -->
+          <iyz>0</iyz>              <!-- 1.17656e-07 -->
+          <izz>6.66667E-06</izz>    <!-- 5.80439e-06 -->
         </inertia>
       </inertial>
       <collision name="collision">
@@ -113,12 +118,12 @@
         <pose>7e-06 -1.2e-05 0.017767 0 0 0</pose>
         <mass>0.01</mass> <!--default :0.0136328 -->
         <inertia>
-          <ixx>4.42921e-06</ixx>
-          <ixy>9.45518e-10</ixy>
-          <ixz>4.79661e-09</ixz>
-          <iyy>4.42799e-06</iyy>
-          <iyz>-2.84067e-08</iyz>
-          <izz>8.68181e-06</izz>
+          <ixx>4.42921e-06</ixx>  <!-- 4.42921e-06-->
+          <ixy>0</ixy>            <!-- 9.45518e-10 -->
+          <ixz>0</ixz>            <!-- 4.79661e-09 -->
+          <iyy>4.42921e-06</iyy>  <!-- 4.42799e-06-->
+          <iyz>0</iyz>            <!-- -2.84067e-08 -->
+          <izz>8.68181e-06</izz>  <!-- 8.68181e-06 -->
           </inertia>
       </inertial>
       <collision name="collision">
@@ -164,25 +169,31 @@
     <link name="cw_servo_link">
       <pose relative_to="cw_servo_joint">0 0 0 0 0 0</pose>
       <inertial>
-        <pose>4e-06 0.00321 0.020676 0 0 0</pose>
-        <mass>0.0318045</mass> 
+        <!-- <pose>4e-06 0.00321 0.020676 0 0 0</pose> -->
+        <pose>0 0 0 0 0 0</pose>
+        <!-- <mass>0.0318045</mass>  -->
+        <mass>0.032</mass>
+        <!--
+          Estimate for inertial based on a solid box with dimensions:
+          <size>0.03 0.04 0.02</size>
+        -->
         <inertia>    
-          <ixx>4.59504e-06</ixx>
-          <ixy>1.40278e-09</ixy>
-          <ixz>7.07896e-10</ixz>
-          <iyy>3.56647e-06</iyy>
-          <iyz>-1.14994e-07</iyz>
-          <izz>5.80439e-06</izz>
+          <ixx>5.33333E-06</ixx>    <!-- 4.59504e-06 -->
+          <ixy>0</ixy>              <!-- 1.40278e-09 -->
+          <ixz>0</ixz>              <!-- 7.07896e-10 -->
+          <iyy>3.46667E-06</iyy>    <!-- 3.56647e-06 -->
+          <iyz>0</iyz>              <!-- -1.14994e-07 -->
+          <izz>6.66667E-06</izz>    <!-- 5.80439e-06 -->
         </inertia>
       </inertial>
-      <box name="collision">
+      <collision name="collision">
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
             <uri>model://bicopter/meshes/cw_servo.stl</uri>
           </mesh>
         </geometry>
-      </box>
+      </collision>
       <visual name="visual">
         <geometry>
           <mesh>
@@ -220,22 +231,22 @@
         <pose>0 9e-06 0.017847 0 0 0</pose>
         <mass>0.01</mass> <!--default :0.0136338, weight -->
         <inertia>
-          <ixx>4.42778e-06</ixx>
-          <ixy>6.06547e-11</ixy>
-          <ixz>1.00593e-08</ixz>
-          <iyy>4.42787e-06</iyy>
-          <iyz>2.69765e-08</iyz>
-          <izz>8.67976e-06</izz>
+          <ixx>4.42921e-06</ixx>  <!-- 4.42778e-06 -->
+          <ixy>0</ixy>            <!-- 6.06547e-11 -->
+          <ixz>0</ixz>            <!-- 1.00593e-08 -->
+          <iyy>4.42921e-06</iyy>  <!-- 4.42787e-06 -->
+          <iyz>0</iyz>            <!-- 2.69765e-08 -->
+          <izz>8.68181e-06</izz>  <!-- 8.67976e-06 -->
         </inertia>
       </inertial>
-      <box name="collision"> <!--"cw-mot_box" -->
+      <collision name="collision"> <!--"cw-mot_box" -->
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
             <uri>model://bicopter/meshes/cw_mot.stl</uri>
           </mesh>
         </geometry>
-      </box>
+      </collision>
       <visual name="visual">
         <geometry>
           <mesh>
@@ -262,23 +273,23 @@
         </limit>
         <xyz>0 0 1</xyz>
         <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
+          <dampint>0.01</dampint>
         </dynamics>
       </axis>
     </joint>
 
     <!-- sensors -->
     <link name="imu_link">
+      <pose>0 0 0.08 0 0 0</pose>
       <inertial>
-        <mass>0.15</mass>
+        <mass>0.05</mass>
         <inertia>
-          <ixx>0.00002</ixx>
+          <ixx>1.33333E-05</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
-          <iyy>0.00002</iyy>
+          <iyy>1.33333E-05</iyy>
           <iyz>0</iyz>
-          <izz>0.00002</izz>
+          <izz>1.33333E-05</izz>
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
@@ -312,13 +323,13 @@
         filename="gz-sim-joint-position-controller-system">
       <joint_name>ccw_servo_joint</joint_name>
       <topic>/ccw_servo_joint/cmd_pos</topic>
-      <p_gain>1</p_gain>
+      <p_gain>0.3</p_gain>
       <i_gain>0</i_gain>
-      <d_gain>0</d_gain>
+      <d_gain>0.001</d_gain>
       <i_max>1</i_max>
       <i_min>-1</i_min>
-      <cmd_max>5</cmd_max>
-      <cmd_min>-5</cmd_min>
+      <cmd_max>2.5</cmd_max>
+      <cmd_min>-2.5</cmd_min>
     </plugin>
 
     <!-- right servo (cw prop) -->
@@ -326,40 +337,38 @@
         filename="gz-sim-joint-position-controller-system">
       <joint_name>cw_servo_joint</joint_name>
       <topic>/cw_servo_joint/cmd_pos</topic>
-      <p_gain>1</p_gain>
+      <p_gain>0.3</p_gain>
       <i_gain>0</i_gain>
-      <d_gain>0</d_gain>
+      <d_gain>0.001</d_gain>
       <i_max>1</i_max>
       <i_min>-1</i_min>
-      <cmd_max>5</cmd_max>
-      <cmd_min>-5</cmd_min>
+      <cmd_max>2.5</cmd_max>
+      <cmd_min>-2.5</cmd_min>
     </plugin>
 
     <!-- left motor thruster (ccw), assume 5 inch props -->
-    <plugin name="gz::sim::systems::Thruster"
+    <!-- <plugin name="gz::sim::systems::Thruster"
       filename="gz-sim-thruster-system">
       <namespace>bicopter</namespace>
       <joint_name>ccw_mot_joint</joint_name>
-      <thrust_coefficient>0.02</thrust_coefficient>
+      <thrust_coefficient>0.001</thrust_coefficient>
       <fluid_density>1.2041</fluid_density>
       <propeller_diameter>0.127</propeller_diameter>
       <velocity_control>0</velocity_control>
       <use_angvel_cmd>0</use_angvel_cmd>
-    </plugin>
+    </plugin> -->
 
     <!-- right motor thruster (cw), assume 5 inch props -->
-    <plugin name="gz::sim::systems::Thruster"
+    <!-- <plugin name="gz::sim::systems::Thruster"
       filename="gz-sim-thruster-system">
       <namespace>bicopter</namespace>
       <joint_name>cw_mot_joint</joint_name>
-      <thrust_coefficient>-0.02</thrust_coefficient>
+      <thrust_coefficient>-0.001</thrust_coefficient>
       <fluid_density>1.2041</fluid_density>
       <propeller_diameter>0.127</propeller_diameter>
       <velocity_control>0</velocity_control>
       <use_angvel_cmd>0</use_angvel_cmd>
-    </plugin>
-
-
+    </plugin> -->
 
   </model>
 </sdf>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -320,7 +320,7 @@
         </inertia>
       </inertial>
       <sensor name="imu_sensor" type="imu">
-        <pose degrees="true">0 0 0 180 0 -90</pose>
+        <pose degrees="true">0 0 0 180 0 0</pose>
         <always_on>1</always_on>
         <update_rate>1000.0</update_rate>
       </sensor>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -1,5 +1,18 @@
 <?xml version="1.0"?>
 <!--
+  Dimensions
+
+  Prop  : 9inch 3p (https://grabcad.com/library/propeller-phantom-3-9450-1)
+  Motor : 2312-920KV (https://grabcad.com/library/dji-2312-e305-motor-1)
+          mass:   50.0g
+          size:   27.7 x 26.0 mm
+          thrust: https://ctu-mrs.github.io/docs/hardware/motor_tests.html
+  ESC   : 30A
+  Servo : HITEC 422 SERVO (https://grabcad.com/library/hitech-servo-hs-422-1)
+          mass:   45.5g
+          torque: 4.1 kg.cm
+          size:   40.6 x 19.8 x 36.8 mm
+
   Joint controllers
 
   Move left (ccw) tilt servo
@@ -75,18 +88,18 @@
       <inertial>
         <!-- <pose>-5e-06 -0.003367 0.021721 0 0 0</pose> -->
         <pose>0 0 0 0 0 0</pose>
-        <mass>0.032</mass> <!-- default : 0.0318045 -->
+        <mass>0.050</mass> <!-- default : 0.0318045 -->
         <!--
           Estimate for inertial based on a solid box with dimensions:
           <size>0.03 0.04 0.02</size>
         -->
         <inertia>
-          <ixx>5.33333E-06</ixx>    <!-- 4.59202e-06 -->
+          <ixx>8.33333E-06</ixx>    <!-- 4.59202e-06 -->
           <ixy>0</ixy>              <!-- -7.94305e-11 -->
           <ixz>0</ixz>              <!-- -1.03122e-09 -->
-          <iyy>3.46667E-06</iyy>    <!-- 3.56948e-06 -->
+          <iyy>5.41667E-06</iyy>    <!-- 3.56948e-06 -->
           <iyz>0</iyz>              <!-- 1.17656e-07 -->
-          <izz>6.66667E-06</izz>    <!-- 5.80439e-06 -->
+          <izz>1.04167E-05</izz>    <!-- 5.80439e-06 -->
         </inertia>
       </inertial>
       <collision name="collision">
@@ -132,14 +145,14 @@
       <pose relative_to="ccw_mot_joint">0 0 0 0 0 0</pose>
       <inertial>
         <pose>7e-06 -1.2e-05 0.017767 0 0 0</pose>
-        <mass>0.01</mass> <!--default :0.0136328 -->
+        <mass>0.050</mass> <!--default :0.0136328 -->
         <inertia>
-          <ixx>4.42921e-06</ixx>  <!-- 4.42921e-06-->
+          <ixx>1.19292E-05</ixx>  <!-- 4.42921e-06-->
           <ixy>0</ixy>            <!-- 9.45518e-10 -->
           <ixz>0</ixz>            <!-- 4.79661e-09 -->
-          <iyy>4.42921e-06</iyy>  <!-- 4.42799e-06-->
+          <iyy>1.19292E-05</iyy>  <!-- 4.42799e-06-->
           <iyz>0</iyz>            <!-- -2.84067e-08 -->
-          <izz>8.68181e-06</izz>  <!-- 8.68181e-06 -->
+          <izz>0.000018225</izz>  <!-- 8.68181e-06 -->
           </inertia>
       </inertial>
       <collision name="collision">
@@ -188,18 +201,18 @@
         <!-- <pose>4e-06 0.00321 0.020676 0 0 0</pose> -->
         <pose>0 0 0 0 0 0</pose>
         <!-- <mass>0.0318045</mass>  -->
-        <mass>0.032</mass>
+        <mass>0.050</mass>
         <!--
           Estimate for inertial based on a solid box with dimensions:
           <size>0.03 0.04 0.02</size>
         -->
         <inertia>    
-          <ixx>5.33333E-06</ixx>    <!-- 4.59504e-06 -->
+          <ixx>8.33333E-06</ixx>    <!-- 4.59504e-06 -->
           <ixy>0</ixy>              <!-- 1.40278e-09 -->
           <ixz>0</ixz>              <!-- 7.07896e-10 -->
-          <iyy>3.46667E-06</iyy>    <!-- 3.56647e-06 -->
+          <iyy>5.41667E-06</iyy>    <!-- 3.56647e-06 -->
           <iyz>0</iyz>              <!-- -1.14994e-07 -->
-          <izz>6.66667E-06</izz>    <!-- 5.80439e-06 -->
+          <izz>1.04167E-05</izz>    <!-- 5.80439e-06 -->
         </inertia>
       </inertial>
       <collision name="collision">
@@ -245,14 +258,14 @@
       <pose relative_to="cw_mot_joint">0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 9e-06 0.017847 0 0 0</pose>
-        <mass>0.01</mass> <!--default :0.0136338, weight -->
+        <mass>0.050</mass> <!--default :0.0136338, weight -->
         <inertia>
-          <ixx>4.42921e-06</ixx>  <!-- 4.42778e-06 -->
+          <ixx>1.19292E-05</ixx>  <!-- 4.42778e-06 -->
           <ixy>0</ixy>            <!-- 6.06547e-11 -->
           <ixz>0</ixz>            <!-- 1.00593e-08 -->
-          <iyy>4.42921e-06</iyy>  <!-- 4.42787e-06 -->
+          <iyy>1.19292E-05</iyy>  <!-- 4.42787e-06 -->
           <iyz>0</iyz>            <!-- 2.69765e-08 -->
-          <izz>8.68181e-06</izz>  <!-- 8.67976e-06 -->
+          <izz>0.000018225</izz>  <!-- 8.67976e-06 -->
         </inertia>
       </inertial>
       <collision name="collision"> <!--"cw-mot_box" -->

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -286,5 +286,65 @@
         </dynamics>
       </axis>
     </joint>
+
+    <!-- plugins -->
+    <plugin name="gz::sim::systems::JointStatePublisher"
+        filename="gz-sim-joint-state-publisher-system">
+    </plugin>
+
+    <!-- left servo (ccw prop) -->
+    <plugin name="gz::sim::systems::JointPositionController"
+        filename="gz-sim-joint-position-controller-system">
+      <joint_name>ccw_servo_joint</joint_name>
+      <topic>/ccw_servo_joint/cmd_pos</topic>
+      <p_gain>1</p_gain>
+      <i_gain>0</i_gain>
+      <d_gain>0</d_gain>
+      <i_max>1</i_max>
+      <i_min>-1</i_min>
+      <cmd_max>5</cmd_max>
+      <cmd_min>-5</cmd_min>
+    </plugin>
+
+    <!-- right servo (cw prop) -->
+    <plugin name="gz::sim::systems::JointPositionController"
+        filename="gz-sim-joint-position-controller-system">
+      <joint_name>cw_servo_joint</joint_name>
+      <topic>/cw_servo_joint/cmd_pos</topic>
+      <p_gain>1</p_gain>
+      <i_gain>0</i_gain>
+      <d_gain>0</d_gain>
+      <i_max>1</i_max>
+      <i_min>-1</i_min>
+      <cmd_max>5</cmd_max>
+      <cmd_min>-5</cmd_min>
+    </plugin>
+
+    <!-- left motor thruster (ccw), assume 5 inch props -->
+    <plugin name="gz::sim::systems::Thruster"
+      filename="gz-sim-thruster-system">
+      <namespace>bicopter</namespace>
+      <joint_name>ccw_mot_joint</joint_name>
+      <thrust_coefficient>0.02</thrust_coefficient>
+      <fluid_density>1.2041</fluid_density>
+      <propeller_diameter>0.127</propeller_diameter>
+      <velocity_control>0</velocity_control>
+      <use_angvel_cmd>0</use_angvel_cmd>
+    </plugin>
+
+    <!-- right motor thruster (cw), assume 5 inch props -->
+    <plugin name="gz::sim::systems::Thruster"
+      filename="gz-sim-thruster-system">
+      <namespace>bicopter</namespace>
+      <joint_name>cw_mot_joint</joint_name>
+      <thrust_coefficient>-0.02</thrust_coefficient>
+      <fluid_density>1.2041</fluid_density>
+      <propeller_diameter>0.127</propeller_diameter>
+      <velocity_control>0</velocity_control>
+      <use_angvel_cmd>0</use_angvel_cmd>
+    </plugin>
+
+
+
   </model>
 </sdf>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -388,7 +388,7 @@
       <cmd_min>-2.5</cmd_min>
     </plugin>
 
-    <!-- left motor (cw prop) -->
+    <!-- right motor (cw prop) -->
     <plugin name="gz::sim::systems::JointController"
       filename="gz-sim-joint-controller-system">
       <joint_name>cw_mot_joint</joint_name>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -66,6 +66,14 @@
             <size>0.16 0.26 0.16</size>
           </box>
         </geometry> -->
+        <surface>
+          <friction>
+            <ode>
+              <mu>1.0</mu>
+              <mu2>1.0</mu2>
+            </ode>
+          </friction>
+        </surface>
       </collision>
       <visual name="visual">
         <geometry>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -1,4 +1,20 @@
 <?xml version="1.0"?>
+<!--
+  Joint controllers
+
+  Move left (ccw) tilt servo
+    gz topic -t "/ccw_servo_joint/cmd_pos" -m gz.msgs.Double -p "data: 0.5"
+
+  Move right (cw) tilt servo
+    gz topic -t "/cw_servo_joint/cmd_pos" -m gz.msgs.Double -p "data: 0.5"
+
+  Command left motor angulkar velocity (ccw)
+    gz topic -t "/model/bicopter/joint/ccw_mot_joint/cmd_vel" -m gz.msgs.Double -p "data: -10.0"
+
+  Command right motor angular velocity (cw)
+    gz topic -t "/model/bicopter/joint/cw_mot_joint/cmd_vel" -m gz.msgs.Double -p "data: 10.0"
+
+-->
 <sdf version="1.9"> 
   <model name="bicopter">
     <pose>0 0 0 0 0 0</pose> <!--원래 값 0 0 0.194923 0 0 0 -->
@@ -346,29 +362,36 @@
       <cmd_min>-2.5</cmd_min>
     </plugin>
 
-    <!-- left motor thruster (ccw), assume 5 inch props -->
-    <!-- <plugin name="gz::sim::systems::Thruster"
-      filename="gz-sim-thruster-system">
-      <namespace>bicopter</namespace>
+    <!-- left motor (ccw prop) -->
+    <plugin name="gz::sim::systems::JointController"
+      filename="gz-sim-joint-controller-system">
       <joint_name>ccw_mot_joint</joint_name>
-      <thrust_coefficient>0.001</thrust_coefficient>
-      <fluid_density>1.2041</fluid_density>
-      <propeller_diameter>0.127</propeller_diameter>
-      <velocity_control>0</velocity_control>
-      <use_angvel_cmd>0</use_angvel_cmd>
-    </plugin> -->
+      <initial_velocity>0.0</initial_velocity>
+      <use_force_commands>false</use_force_commands>
+      <p_gain>0.01</p_gain>
+      <i_gain>0.0</i_gain>
+      <d_gain>0.0</d_gain>
+      <i_max>1</i_max>
+      <i_min>-1</i_min>
+      <cmd_max>2.5</cmd_max>
+      <cmd_min>-2.5</cmd_min>
+    </plugin>
 
-    <!-- right motor thruster (cw), assume 5 inch props -->
-    <!-- <plugin name="gz::sim::systems::Thruster"
-      filename="gz-sim-thruster-system">
-      <namespace>bicopter</namespace>
+    <!-- left motor (cw prop) -->
+    <plugin name="gz::sim::systems::JointController"
+      filename="gz-sim-joint-controller-system">
       <joint_name>cw_mot_joint</joint_name>
-      <thrust_coefficient>-0.001</thrust_coefficient>
-      <fluid_density>1.2041</fluid_density>
-      <propeller_diameter>0.127</propeller_diameter>
-      <velocity_control>0</velocity_control>
-      <use_angvel_cmd>0</use_angvel_cmd>
-    </plugin> -->
+      <initial_velocity>0.0</initial_velocity>
+      <use_force_commands>false</use_force_commands>
+      <p_gain>0.01</p_gain>
+      <i_gain>0.0</i_gain>
+      <d_gain>0.0</d_gain>
+      <i_max>1</i_max>
+      <i_min>-1</i_min>
+      <cmd_max>2.5</cmd_max>
+      <cmd_min>-2.5</cmd_min>
+    </plugin>
+
 
   </model>
 </sdf>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -403,6 +403,111 @@
       <cmd_min>-2.5</cmd_min>
     </plugin>
 
+    <!-- left (ccw) lift-drag -->
+    <plugin name="gz::sim::systems::LiftDrag"
+      filename="gz-sim-lift-drag-system">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.00</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>0.084 0 0</cp>
+      <forward>0 1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>ccw_mot_link</link_name>
+    </plugin>
+    <plugin name="gz::sim::systems::LiftDrag"
+      filename="gz-sim-lift-drag-system">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.00</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.042 0.072746134 0</cp>
+      <forward>-0.866025404 -0.5 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>ccw_mot_link</link_name>
+    </plugin>
+    <plugin name="gz::sim::systems::LiftDrag"
+      filename="gz-sim-lift-drag-system">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.00</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.042 -0.072746134 0</cp>
+      <forward>0.866025404 -0.5 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>ccw_mot_link</link_name>
+    </plugin>
+
+    <!-- prop_left (cw) lift-drag (ArduPilot motor 2) -->
+    <plugin name="gz::sim::systems::LiftDrag"
+      filename="gz-sim-lift-drag-system">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.00</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>0.084 0 0</cp>
+      <forward>0 -1 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>cw_mot_link</link_name>
+    </plugin>
+    <plugin name="gz::sim::systems::LiftDrag"
+      filename="gz-sim-lift-drag-system">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.00</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.042 0.072746134 0</cp>
+      <forward>0.866025404 0.5 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>cw_mot_link</link_name>
+    </plugin>
+    <plugin name="gz::sim::systems::LiftDrag"
+      filename="gz-sim-lift-drag-system">
+      <a0>0.3</a0>
+      <alpha_stall>1.4</alpha_stall>
+      <cla>4.2500</cla>
+      <cda>0.10</cda>
+      <cma>0.00</cma>
+      <cla_stall>-0.025</cla_stall>
+      <cda_stall>0.0</cda_stall>
+      <cma_stall>0.0</cma_stall>
+      <area>0.002</area>
+      <air_density>1.2041</air_density>
+      <cp>-0.042 0.072746134 0</cp>
+      <forward>-0.866025404 0.5 0</forward>
+      <upward>0 0 1</upward>
+      <link_name>cw_mot_link</link_name>
+    </plugin>
 
   </model>
 </sdf>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -1,18 +1,24 @@
 <?xml version="1.0"?>
 <sdf version="1.9"> 
   <model name="bicopter">
-    <pose>0 0 0.1 0 0 0</pose> <!--원래 값 0 0 0.194923 0 0 0 -->
+    <pose>0 0 0 0 0 0</pose> <!--원래 값 0 0 0.194923 0 0 0 -->
     <link name="base_link">
       <inertial>
-        <pose>0.002973 0.001387 0.095001 0 0 0</pose> <!--Default : 0.002973 0.001387 0.095001 0 0 0-->
-        <mass>0.02</mass> <!--원래 값 mass 0.390996-->
+        <!-- <pose>0.002973 0.001387 0.095001 0 0 0</pose> --> <!--Default : 0.002973 0.001387 0.095001 0 0 0-->
+        <pose>0.002973 0 0.08 0 0 0</pose>
+        <!-- <mass>0.02</mass> --> <!--원래 값 mass 0.390996-->
+        <!--
+          Estimate for inertial based on a solid box with dimensions:
+          <size>0.16 0.12 0.10</size>
+        -->
+        <mass>0.40</mass>
         <inertia>
-          <ixx>0.00019185</ixx>
-          <ixy>4.02647e-07</ixy>
-          <ixz>-7.71289e-06</ixz> <!--원래 값 -7.71289e-06 -->
-          <iyy>0.000465506</iyy>
-          <iyz>-7.27837e-14</iyz> <!--원래 값 -7.27837e-14 -->
-          <izz>0.000526809</izz>
+          <ixx>0.000813333</ixx>  <!--원래 값 0.00019185 -->
+          <ixy>0</ixy>
+          <ixz>0</ixz>            <!--원래 값 -7.71289e-06 -->
+          <iyy>0.001186667</iyy>  <!--원래 값 0.000465506 -->
+          <iyz>0</iyz>            <!--원래 값 -7.27837e-14 -->
+          <izz>0.001333333</izz>  <!--원래 값 0.000526809 -->
         </inertia>
       </inertial>
       <collision name="collision"> <!--Default : collision 오류 발생으로 _box 로 변경 -->
@@ -22,6 +28,15 @@
             <uri>model://bicopter/meshes/base.stl</uri>
           </mesh>
         </geometry>
+        <!--
+          Collision approximation:
+        -->
+        <!-- <pose>0 0 0.08 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.16 0.26 0.16</size>
+          </box>
+        </geometry> -->
       </collision>
       <visual name="visual">
         <geometry>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -129,9 +129,9 @@
       <parent>base_link</parent>
       <child>ccw_servo_link</child>
       <axis>
-        <xyz>0 -1 0</xyz> <!-- default : 0 -1 0 0 0 0 -->
+        <xyz>0 -1 0</xyz>
         <limit>    
-          <lower>-0.5</lower> <!-- default : lower -0.5, upper 0.5 -->
+          <lower>-0.5</lower>
           <upper>0.5</upper>
         </limit>
         <dynamics>
@@ -177,15 +177,15 @@
         </material>
       </visual>
     </link>
-    <joint name="ccw_mot_joint" type="revolute"> <!-- 기수 기준, Left motor -->
+    <joint name="ccw_mot_joint" type="revolute">
       <pose relative_to="ccw_servo_link">0 -0.004 0.0425 0 0 0</pose>
       <parent>ccw_servo_link</parent>
       <child>ccw_mot_link</child>
       <axis>
         <xyz>0 0 -1</xyz>
         <limit>
-          <lower>-1e+16</lower> <!--default : 1e+16 -->
-          <upper>1e+16</upper> <!--default : -1e+16 -->
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
         </limit>
         <dynamics>
           <damping>0.004</damping>
@@ -243,7 +243,7 @@
       <axis>    
         <xyz>0 1 0</xyz>
         <limit>
-          <lower>-0.5</lower> <!-- 정규 값 : lower -0.5, upper 0.5 -->
+          <lower>-0.5</lower>
           <upper>0.5</upper>
         </limit>
         <dynamics>
@@ -289,15 +289,15 @@
         </material>
       </visual>
       </link>
-    <joint name="cw_mot_joint" type="revolute"> <!-- 기수 기준, Right motor --> 
+    <joint name="cw_mot_joint" type="revolute"> 
       <pose relative_to="cw_servo_link">0 0.003829 0.041455 0 0 0</pose>
       <parent>cw_servo_link</parent>
       <child>cw_mot_link</child>
       <axis>
-        <xyz>0 0 -1</xyz> <!-- 원래 값 : -1 -->
+        <xyz>0 0 -1</xyz>
         <limit>
-          <lower>-1e+16</lower> <!--default : 1e+16 -->
-          <upper>1e+16</upper> <!--default : -1e+16 -->
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
         </limit>
         <dynamics>
           <damping>0.004</damping>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -422,7 +422,7 @@
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
+      <area>0.0013</area>
       <air_density>1.2041</air_density>
       <cp>0.084 0 0</cp>
       <forward>0 1 0</forward>
@@ -439,7 +439,7 @@
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
+      <area>0.0013</area>
       <air_density>1.2041</air_density>
       <cp>-0.042 0.072746134 0</cp>
       <forward>-0.866025404 -0.5 0</forward>
@@ -456,7 +456,7 @@
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
+      <area>0.0013</area>
       <air_density>1.2041</air_density>
       <cp>-0.042 -0.072746134 0</cp>
       <forward>0.866025404 -0.5 0</forward>
@@ -475,7 +475,7 @@
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
+      <area>0.0013</area>
       <air_density>1.2041</air_density>
       <cp>0.084 0 0</cp>
       <forward>0 -1 0</forward>
@@ -492,7 +492,7 @@
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
+      <area>0.0013</area>
       <air_density>1.2041</air_density>
       <cp>-0.042 0.072746134 0</cp>
       <forward>0.866025404 0.5 0</forward>
@@ -509,7 +509,7 @@
       <cla_stall>-0.025</cla_stall>
       <cda_stall>0.0</cda_stall>
       <cma_stall>0.0</cma_stall>
-      <area>0.002</area>
+      <area>0.0013</area>
       <air_density>1.2041</air_density>
       <cp>-0.042 0.072746134 0</cp>
       <forward>-0.866025404 0.5 0</forward>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -135,7 +135,7 @@
           <upper>0.5</upper>
         </limit>
         <dynamics>
-          <damping>0.01</damping>
+          <damping>0.004</damping> 
         </dynamics>
       </axis>      
     </joint>
@@ -187,9 +187,8 @@
           <lower>-1e+16</lower> <!--default : 1e+16 -->
           <upper>1e+16</upper> <!--default : -1e+16 -->
         </limit>
-        <xyz>0 0 -1</xyz>
         <dynamics>
-          <damping>0.01</damping>
+          <damping>0.004</damping>
         </dynamics>
       </axis>
     </joint>
@@ -248,7 +247,7 @@
           <upper>0.5</upper>
         </limit>
         <dynamics>
-          <damping>0.01</damping>
+          <damping>0.004</damping>
         </dynamics>
       </axis>
     </joint>
@@ -300,9 +299,8 @@
           <lower>-1e+16</lower> <!--default : 1e+16 -->
           <upper>1e+16</upper> <!--default : -1e+16 -->
         </limit>
-        <xyz>0 0 1</xyz>
         <dynamics>
-          <dampint>0.01</dampint>
+          <damping>0.004</damping>
         </dynamics>
       </axis>
     </joint>

--- a/models/bicopter/model.sdf
+++ b/models/bicopter/model.sdf
@@ -139,8 +139,8 @@
       <axis>
         <xyz>0 -1 0</xyz>
         <limit>    
-          <lower>-0.5</lower>
-          <upper>0.5</upper>
+          <lower>-0.785398163</lower>
+          <upper>0.785398163</upper>
         </limit>
         <dynamics>
           <damping>0.004</damping> 
@@ -251,8 +251,8 @@
       <axis>    
         <xyz>0 1 0</xyz>
         <limit>
-          <lower>-0.5</lower>
-          <upper>0.5</upper>
+          <lower>-0.785398163</lower>
+          <upper>0.785398163</upper>
         </limit>
         <dynamics>
           <damping>0.004</damping>

--- a/worlds/bicopter_runway.sdf
+++ b/worlds/bicopter_runway.sdf
@@ -49,6 +49,7 @@
     </include>
 
     <include>
+      <pose>0 0 0.1 0 0 0</pose>
       <uri>model://bicopter</uri>
     </include>
 

--- a/worlds/bicopter_runway.sdf
+++ b/worlds/bicopter_runway.sdf
@@ -49,7 +49,7 @@
     </include>
 
     <include>
-      <pose>0 0 0.1 0 0 0</pose>
+      <pose>0 0 0.03 0 0 0</pose>
       <uri>model://bicopter</uri>
     </include>
 


### PR DESCRIPTION
Add joint position and velocity control plugins and configure lift drag plugins for tri-blade props.

The joints can be tested using the Gazebo topic commands:

Move left (ccw) tilt servo

```bash
gz topic -t "/ccw_servo_joint/cmd_pos" -m gz.msgs.Double -p "data: 0.5"
```

Move right (cw) tilt servo

```bash
gz topic -t "/cw_servo_joint/cmd_pos" -m gz.msgs.Double -p "data: 0.5"
```

Command left motor angulkar velocity (ccw)

```bash
gz topic -t "/model/bicopter/joint/ccw_mot_joint/cmd_vel" -m gz.msgs.Double -p "data: -10.0"
```

Command right motor angular velocity (cw)

```bash
gz topic -t "/model/bicopter/joint/cw_mot_joint/cmd_vel" -m gz.msgs.Double -p "data: 10.0"
```

https://github.com/GreenPine-CK/bicopter_simulation/assets/24916364/e9303fd6-8d24-4c51-a1c4-b1a57bf9eea8

