### PR TITLE
Add package, cmake file and hooks for colcon build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.5)
+project(bicopter_gz_description)
+
+# --------------------------------------------------------------------------- #
+# Find dependencies.
+find_package(ament_cmake REQUIRED)
+
+find_package(gz-cmake3 REQUIRED)
+
+find_package(gz-sim7 REQUIRED)
+set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
+
+# --------------------------------------------------------------------------- #
+#  Build.
+
+# --------------------------------------------------------------------------- #
+#  Install.
+
+# Install project configuration files.
+install(
+  DIRECTORY
+    config/
+  DESTINATION share/${PROJECT_NAME}/config
+)
+
+# Install project model files.
+install(
+  DIRECTORY models/
+  DESTINATION share/${PROJECT_NAME}/models
+)
+
+# Install project world files.
+install(
+  DIRECTORY worlds/
+  DESTINATION share/${PROJECT_NAME}/worlds
+)
+
+# --------------------------------------------------------------------------- #
+#  Build tests.
+
+if(BUILD_TESTING)
+  # Override default flake8 configuration.
+  set(ament_cmake_flake8_CONFIG_FILE ${CMAKE_SOURCE_DIR}/.flake8)
+
+  # Add linters.
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# --------------------------------------------------------------------------- #
+#  Environment hooks.
+
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.sh.in")
+
+# --------------------------------------------------------------------------- #
+#  Call last.
+
+ament_package()

--- a/hooks/bicopter_gz_description.dsv.in
+++ b/hooks/bicopter_gz_description.dsv.in
@@ -1,0 +1,4 @@
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share;@CMAKE_INSTALL_PREFIX@/share
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/models
+prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/worlds
+prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/@PROJECT_NAME@/

--- a/hooks/bicopter_gz_description.sh.in
+++ b/hooks/bicopter_gz_description.sh.in
@@ -1,0 +1,3 @@
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
+ament_prepend_unique_value GZ_SIM_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>bicopter_gz_description</name>
+  <version>0.0.0</version>
+  <description>BiCopter Gazebo models configured for ArduPilot SITL</description>
+  <maintainer email="maintainer@gmail.com">Maintainer</maintainer>
+  <license>TODO</license>
+  <author>Author</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <exec_depend>ardupilot_gazebo</exec_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
Enable the package to be built using colcon. This will also add the necessary `GZ_SIM_*` variables to the environment when sourcing the build packages with `source ./install/setup.bash`.

Should be rebase-merged after #2.

### Usage

```bash
$ cd ros_ws
$ colcon build bicopter_gz_description
$ source ./install/setup.bash
```

